### PR TITLE
add .travis.yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: perl
+sudo: false
+perl:
+ - "5.12"
+ - "5.14"
+ - "5.16"
+ - "5.18"
+ - "5.20"
+ - "5.22"
+ - "5.24"
+ - "5.26"
+matrix:
+  include:
+    - perl: 5.18
+      env: COVERAGE=1   # enables coverage+coveralls reporting
+  allow_failures:
+    - perl: blead       # ignore failures for blead perl
+before_install:
+  - git clone git://github.com/haarg/perl-travis-helper
+  - source perl-travis-helper/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR
+
+install:
+  - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=c HARNESS_TIMER=1
+  - cpanm --quiet --notest Devel::Cover::Report::Coveralls Pod::Coverage::TrustPod Test::CPAN::Meta
+  - cpanm --quiet --notest --installdeps .
+  - cpanm --quiet --notest --with-develop .
+
+script:
+  - PERL5OPT=-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine prove -lrsv t
+  - cover
+
+after_success:
+  - cover -report coveralls


### PR DESCRIPTION
This adds Travis and Coveralls support. TravisCI is a continuous integration system that is free for open source projects. It allows you to automatically run your tests whenever you push a branch or someone creates a PR. I've set my branch up in my own account for you to take a look at https://travis-ci.org/simbabque/SQLite-Work.

In order to use it, you need to create an account at https://travis-ci.org/ and sync it with your github account. 

In addition to that, there is also https://coveralls.io/, which is hooked up to Travis. It collects coverage data from the test runs in Travis. You can look at my fork at https://coveralls.io/github/simbabque/SQLite-Work. Again, you have to create your own account and sync it with your github profile.

This is my entry for the CPAN Pull Request Challenge in February 2018. It was intended to be for January, but I unfortunately did not have time to work on it earlier.